### PR TITLE
fix mass reassignment outside of allowed bounds

### DIFF
--- a/transitleastsquares/grid.py
+++ b/transitleastsquares/grid.py
@@ -85,7 +85,7 @@ def period_grid(
             + ")"
         )
         warnings.warn(text)
-        R_star = 0.01
+        M_star = 0.01
 
     if M_star > 1000:
         text = (
@@ -94,7 +94,7 @@ def period_grid(
             + ")"
         )
         warnings.warn(text)
-        R_star = 1000
+        M_star = 1000
 
     R_star = R_star * tls_constants.R_sun
     M_star = M_star * tls_constants.M_sun


### PR DESCRIPTION
Code is supposed to reassign mass if outside physical range, but appeared to reassign radius to the mass limit if the mass was outside the allowed range.