### PR TITLE
Only require argparse when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='transitleastsquares',
         'numba',
         'tqdm',
         'batman-package',
-        'argparse',
+        'argparse; python_version < "2.7"',
         'configparser'
         ]
 )


### PR DESCRIPTION
`argparse` is available in the stdlib in all non-ancient Python versions (2.7+), and installing it is pointless because the stdlib copy always takes precedence. The name conflict, however, causes problems in some edge cases and makes installing packages depending on TransitLeastSquares impossible.

This patch adds an [environment marker](https://www.python.org/dev/peps/pep-0508/#environment-markers), so the library is only pulled in when `argparse` is not present.

Thank you for your contribution to TLS. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] [Existing test cases](https://github.com/hippke/tls/tree/master/transitleastsquares/tests) work correctly
- [x] New test cases have been added to cover the additional and/or changed functionality
