### PR TITLE
Update helpers.py

### DIFF
--- a/transitleastsquares/helpers.py
+++ b/transitleastsquares/helpers.py
@@ -93,7 +93,7 @@ def running_mean_equal_length(data, width_signal):
 def running_median(data, kernel):
     """Returns sliding median of width 'kernel' and same length as data """
     idx = numpy.arange(kernel) + numpy.arange(len(data) - kernel + 1)[:, None]
-    idx = idx.astype(numpy.int)  # needed if oversampling_factor is not int
+    idx = idx.astype(numpy.int64)  # needed if oversampling_factor is not int
     med = numpy.median(data[idx], axis=1)
 
     # Append the first/last value at the beginning/end to match the length of


### PR DESCRIPTION
numpy.int was deprecated in numpy v1.20, changed helpers.py (the only place I could find it)

Thank you for your contribution to TLS. 
Before submitting this PR, please make sure:

- [X] Your code builds clean without any errors or warnings
- [X] [Existing test cases](https://github.com/hippke/tls/tree/master/transitleastsquares/tests) work correctly
- [ ] New test cases have been added to cover the additional and/or changed functionality
(no new test cases needed, change is tiny)